### PR TITLE
修复 PacketContainer 会错误引用玩家物品栏的 BUG

### DIFF
--- a/src/main/java/lnatit/mcardsth/MineCardsTouhou.java
+++ b/src/main/java/lnatit/mcardsth/MineCardsTouhou.java
@@ -1,6 +1,7 @@
 package lnatit.mcardsth;
 
 import lnatit.mcardsth.entity.EntityTypeReg;
+import lnatit.mcardsth.gui.ContainerTypeReg;
 import lnatit.mcardsth.item.ItemReg;
 import lnatit.mcardsth.utils.Config;
 import net.minecraftforge.fml.ModLoadingContext;
@@ -21,7 +22,7 @@ public class MineCardsTouhou
     {
         ItemReg.ITEMS.register(FMLJavaModLoadingContext.get().getModEventBus());
         EntityTypeReg.ENTITIES.register(FMLJavaModLoadingContext.get().getModEventBus());
-
+        ContainerTypeReg.CONTAINERS.register(FMLJavaModLoadingContext.get().getModEventBus());
         ModLoadingContext.get().registerConfig(ModConfig.Type.COMMON, Config.init());
     }
 }

--- a/src/main/java/lnatit/mcardsth/gui/ClientGuiUtil.java
+++ b/src/main/java/lnatit/mcardsth/gui/ClientGuiUtil.java
@@ -1,14 +1,17 @@
 package lnatit.mcardsth.gui;
 
 import net.minecraft.client.Minecraft;
+import net.minecraft.client.gui.ScreenManager;
 import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.inventory.container.ContainerType;
 import net.minecraft.world.World;
+
+import static lnatit.mcardsth.gui.ContainerTypeReg.PACKET;
 
 public class ClientGuiUtil
 {
-    public static void displayGuiScreen(World world, PlayerEntity player)
+    public static void clientInit()
     {
-        if (world.isRemote)
-            Minecraft.getInstance().displayGuiScreen(new PacketScreen(player));
+        ScreenManager.registerFactory((ContainerType<PacketContainer>) PACKET.get(), PacketScreen::new);
     }
 }

--- a/src/main/java/lnatit/mcardsth/gui/ContainerTypeReg.java
+++ b/src/main/java/lnatit/mcardsth/gui/ContainerTypeReg.java
@@ -1,0 +1,18 @@
+package lnatit.mcardsth.gui;
+
+import net.minecraft.client.Minecraft;
+import net.minecraft.inventory.container.ContainerType;
+import net.minecraft.item.Item;
+import net.minecraftforge.common.extensions.IForgeContainerType;
+import net.minecraftforge.fml.RegistryObject;
+import net.minecraftforge.registries.DeferredRegister;
+import net.minecraftforge.registries.ForgeRegistries;
+
+import static lnatit.mcardsth.MineCardsTouhou.MOD_ID;
+
+public class ContainerTypeReg
+{
+    public static final DeferredRegister<ContainerType<?>> CONTAINERS = DeferredRegister.create(ForgeRegistries.CONTAINERS, MOD_ID);
+
+    public static final RegistryObject<ContainerType<?>> PACKET = CONTAINERS.register("packet", () -> IForgeContainerType.create(((windowId, inv, data) -> new PacketContainer(windowId, inv))));
+}

--- a/src/main/java/lnatit/mcardsth/gui/PacketContainer.java
+++ b/src/main/java/lnatit/mcardsth/gui/PacketContainer.java
@@ -17,14 +17,13 @@ import net.minecraftforge.fml.RegistryObject;
 
 import static lnatit.mcardsth.gui.PacketScreen.INVENTORY;
 
-@OnlyIn(Dist.CLIENT)
 public class PacketContainer extends Container
 {
     public final NonNullList<ItemStack> itemList = NonNullList.create();
 
-    protected PacketContainer(PlayerEntity player)
+    public PacketContainer(int windowId, PlayerInventory inv)
     {
-        super((ContainerType<?>) null, 0);
+        super(ContainerTypeReg.PACKET.get(), windowId);
         for (RegistryObject<Item> itemObj : ItemReg.ITEMS.getEntries())
         {
             Item item = itemObj.get();
@@ -32,8 +31,6 @@ public class PacketContainer extends Container
             itemList.add(new ItemStack(item));
         }
         this.InventoryInit();
-
-        PlayerInventory playerinventory = player.inventory;
 
         for (int i = 0; i < 7; ++i)
         {
@@ -44,7 +41,7 @@ public class PacketContainer extends Container
         }
 
         for (int k = 0; k < 9; ++k)
-            this.addSlot(new Slot(playerinventory, k, 8 + k * 18, 158));
+            this.addSlot(new Slot(inv, k, 8 + k * 18, 158));
     }
 
     @Override

--- a/src/main/java/lnatit/mcardsth/gui/PacketScreen.java
+++ b/src/main/java/lnatit/mcardsth/gui/PacketScreen.java
@@ -4,8 +4,10 @@ import com.mojang.blaze3d.matrix.MatrixStack;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.DisplayEffectsScreen;
 import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.entity.player.PlayerInventory;
 import net.minecraft.inventory.Inventory;
 import net.minecraft.util.ResourceLocation;
+import net.minecraft.util.text.ITextComponent;
 import net.minecraft.util.text.TranslationTextComponent;
 import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.api.distmarker.OnlyIn;
@@ -16,16 +18,14 @@ import static lnatit.mcardsth.MineCardsTouhou.MOD_ID;
 public class PacketScreen extends DisplayEffectsScreen<PacketContainer>
 {
     private static final ResourceLocation PACKET_CONTAINER_RESOURCE = new ResourceLocation(MOD_ID, "textures/gui/packet.png");
-    public static final String TITLE = "container.minecardstouhou.packetscreen";
     private final int textureWidth = 176;
     private final int textureHeight = 182;
 
     protected static final Inventory INVENTORY = new Inventory(63);
 
-    public PacketScreen(PlayerEntity player)
+    public PacketScreen(PacketContainer container, PlayerInventory inv, ITextComponent name)
     {
-        super(new PacketContainer(player), player.inventory, new TranslationTextComponent(TITLE));
-        player.openContainer = this.container;
+        super(container, inv, name);
         this.passEvents = true;
         this.minecraft = Minecraft.getInstance();
         this.xSize = textureWidth;

--- a/src/main/java/lnatit/mcardsth/handler/ClientEventHandler.java
+++ b/src/main/java/lnatit/mcardsth/handler/ClientEventHandler.java
@@ -3,6 +3,7 @@ package lnatit.mcardsth.handler;
 import lnatit.mcardsth.entity.CardEntity;
 import lnatit.mcardsth.entity.CardRenderer;
 import lnatit.mcardsth.entity.EntityTypeReg;
+import lnatit.mcardsth.gui.ClientGuiUtil;
 import lnatit.mcardsth.item.AbstractCard;
 import lnatit.mcardsth.item.ItemReg;
 import lnatit.mcardsth.item.TenkyusPacket;
@@ -49,6 +50,7 @@ public class ClientEventHandler
                                                         );
 
         event.enqueueWork(ClientEventHandler::registerProperties);
+        ClientGuiUtil.clientInit();
     }
 
     private static void registerProperties()

--- a/src/main/java/lnatit/mcardsth/item/TenkyusPacket.java
+++ b/src/main/java/lnatit/mcardsth/item/TenkyusPacket.java
@@ -1,23 +1,30 @@
 package lnatit.mcardsth.item;
 
 import lnatit.mcardsth.gui.ClientGuiUtil;
+import lnatit.mcardsth.gui.PacketContainer;
 import lnatit.mcardsth.gui.PacketScreen;
 import net.minecraft.client.Minecraft;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.entity.player.ServerPlayerEntity;
+import net.minecraft.inventory.container.INamedContainerProvider;
+import net.minecraft.inventory.container.SimpleNamedContainerProvider;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.item.Rarity;
 import net.minecraft.util.ActionResult;
 import net.minecraft.util.Hand;
+import net.minecraft.util.text.ITextComponent;
 import net.minecraft.util.text.TranslationTextComponent;
 import net.minecraft.world.World;
+import net.minecraftforge.fml.network.NetworkHooks;
 
 import static lnatit.mcardsth.utils.PlayerPropertiesUtils.doPlayersAbilityEnabled;
 import static lnatit.mcardsth.utils.PlayerPropertiesUtils.enablePlayerAbility;
 
 public class TenkyusPacket extends Item
 {
+    private static final ITextComponent CONTAINER_NAME = new TranslationTextComponent("container.minecardstouhou.packetscreen");
+
     public TenkyusPacket()
     {
         super(new Item.Properties()
@@ -44,8 +51,13 @@ public class TenkyusPacket extends Item
                     playerIn.sendMessage(new TranslationTextComponent("enabled"), null);
             }
         }
-        else
-            ClientGuiUtil.displayGuiScreen(worldIn, playerIn);
+        else if (playerIn instanceof ServerPlayerEntity)
+            NetworkHooks.openGui((ServerPlayerEntity) playerIn, getContainer());
         return ActionResult.resultSuccess(playerIn.getHeldItem(handIn));
+    }
+
+    public static INamedContainerProvider getContainer()
+    {
+        return new SimpleNamedContainerProvider((id, inventory, player) -> new PacketContainer(id, inventory), CONTAINER_NAME);
     }
 }


### PR DESCRIPTION
初步推断是因为 Container 单端操作的原因
后台报错为数组下标越界
现已修改为利用 ContainerType 在逻辑服务端打开
以后如果是引用玩家物品栏的 GUI
建议使用该种方法进行双端同步